### PR TITLE
Enable edge-to-edge by default

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId = "com.uravgcode.chooser"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 9
         versionName = "1.3.1"
 

--- a/app/src/main/java/com/uravgcode/chooser/MainActivity.kt
+++ b/app/src/main/java/com/uravgcode/chooser/MainActivity.kt
@@ -1,18 +1,20 @@
 package com.uravgcode.chooser
 
-import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import com.uravgcode.chooser.databinding.ActivityMainBinding
 import com.uravgcode.chooser.utilities.Mode
 
-class MainActivity : Activity() {
+class MainActivity : ComponentActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var preferences: SharedPreferences
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         binding.chooser.motionLayout = binding.motionLayout


### PR DESCRIPTION
Hi, I'm not sure you want this change, but in my opinion it looks much better now on devices with all sorts of display cutouts, below is a short comparison.

Also it will be the default on devices targeting SDK 35, so I tried bumping that too and it didn't result in any issues.

If you disagree with the change, or you'd like to do it differently, feel free to close this PR or request modifications to it.

### comparision

before:
(notice black bar at the top of the screen (there's also one around navigation pill / buttons, but it's less visible)

https://github.com/UrAvgCode/Chooser/assets/56438628/68e769a3-babf-40f2-b1d0-d889e2d166d0

after:
(whole screen is used for effects, with no black bars)

https://github.com/UrAvgCode/Chooser/assets/56438628/ab4ee3e9-5630-40d3-95b0-1c749a6f82e3

