### PR TITLE
settings screen scroll fix, settings reset option and slider for additional top padding

### DIFF
--- a/app/src/main/java/com/uravgcode/chooser/composables/buttons/AnimatedButton.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/buttons/AnimatedButton.kt
@@ -33,7 +33,8 @@ fun AnimatedButton(
     onClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
     content: @Composable () -> Unit,
-    alignment: Alignment
+    alignment: Alignment,
+    additionalTopPadding: Float
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         AnimatedVisibility(
@@ -43,12 +44,13 @@ fun AnimatedButton(
                 animationSpec = tween(durationMillis = 400)
             ),
             exit = slideOutVertically(
-                targetOffsetY = { fullHeight -> -2 * fullHeight },
+                targetOffsetY = { fullHeight -> -2 * fullHeight - additionalTopPadding.toInt()},
                 animationSpec = tween(durationMillis = 400)
             ),
             modifier = Modifier
                 .align(alignment)
                 .padding(24.dp)
+                .padding(top = additionalTopPadding.dp)
         ) {
             BaseButton(
                 onClick = onClick,

--- a/app/src/main/java/com/uravgcode/chooser/composables/screens/ChooserScreen.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/screens/ChooserScreen.kt
@@ -71,7 +71,8 @@ fun ChooserScreen(onNavigate: () -> Unit) {
                 contentDescription = "Mode"
             )
         },
-        alignment = Alignment.TopStart
+        alignment = Alignment.TopStart,
+        additionalTopPadding = SettingsManager.additionalTopPadding
     )
 
     AnimatedButton(
@@ -88,6 +89,7 @@ fun ChooserScreen(onNavigate: () -> Unit) {
                 fontSize = 36.sp
             )
         },
-        alignment = Alignment.TopEnd
+        alignment = Alignment.TopEnd,
+        additionalTopPadding = SettingsManager.additionalTopPadding
     )
 }

--- a/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
@@ -9,7 +9,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @author UrAvgCode
+ * @author UrAvgCode, Patch4Code
  * @description SettingsScreen is the settings screen of the application.
  */
 
@@ -61,7 +61,7 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
         showResetDialog = showResetDialog.value,
         onDismiss = { showResetDialog.value = false },
         onReset = {
-            SettingsManager.resetToDefault(context)
+            SettingsManager.reset()
 
             isSoundEnabled.value = SettingsManager.soundEnabled
             isVibrationEnabled.value = SettingsManager.vibrationEnabled

--- a/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
@@ -15,9 +15,14 @@
 
 package com.uravgcode.chooser.composables.screens
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -77,13 +82,13 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
 
     Scaffold(
         topBar = {
-            SettingsTopAppBar(onNavigateBack){
-                showResetDialog.value = true
-            }
+            SettingsTopAppBar(onNavigateBack)
         }
     ) { padding ->
         LazyColumn(
-            modifier = Modifier.padding(padding).padding(16.dp)
+            modifier = Modifier
+                .padding(padding)
+                .padding(16.dp)
         ) {
             item {
 
@@ -175,6 +180,20 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
                     valueRange = 0L..3000L,
                     steps = 5,
                 )
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                ) {
+                    ElevatedButton(
+                        content = { Text("Reset Settings") },
+                        onClick = { showResetDialog.value = true },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.uravgcode.chooser.composables.settings.ResetDialog
 import com.uravgcode.chooser.composables.settings.RestartDialog
+import com.uravgcode.chooser.composables.settings.SettingsRowPaddingSlider
 import com.uravgcode.chooser.composables.settings.SettingsRowPercentSlider
 import com.uravgcode.chooser.composables.settings.SettingsRowSwitch
 import com.uravgcode.chooser.composables.settings.SettingsRowTimeSlider
@@ -45,6 +46,7 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
     val isVibrationEnabled = remember { mutableStateOf(SettingsManager.vibrationEnabled) }
     val isEdgeToEdgeEnabled = remember { mutableStateOf(SettingsManager.edgeToEdgeEnabled) }
     val circleSizeFactor = remember { mutableFloatStateOf(SettingsManager.circleSizeFactor) }
+    val additionalTopPadding = remember { mutableFloatStateOf(SettingsManager.additionalTopPadding) }
 
     val circleLifetime = remember { mutableLongStateOf(SettingsManager.circleLifetime) }
     val groupCircleLifetime = remember { mutableLongStateOf(SettingsManager.groupCircleLifetime) }
@@ -60,6 +62,7 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
             isVibrationEnabled.value = SettingsManager.vibrationEnabled
             isEdgeToEdgeEnabled.value = SettingsManager.edgeToEdgeEnabled
             circleSizeFactor.floatValue = SettingsManager.circleSizeFactor
+            additionalTopPadding.floatValue = SettingsManager.additionalTopPadding
             circleLifetime.longValue = SettingsManager.circleLifetime
             groupCircleLifetime.longValue = SettingsManager.groupCircleLifetime
             orderCircleLifetime.longValue = SettingsManager.orderCircleLifetime
@@ -125,6 +128,17 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
                     },
                     valueRange = 0.5f..1.5f,
                     steps = 9
+                )
+
+                SettingsRowPaddingSlider(
+                    title = "Additional Top Padding",
+                    value = additionalTopPadding.floatValue,
+                    onValueChange = { sliderValue ->
+                        additionalTopPadding.floatValue = sliderValue
+                        SettingsManager.additionalTopPadding = sliderValue
+                    },
+                    valueRange = 0f..50f,
+                    steps = 50
                 )
 
                 SettingsSeparator("Circle Lifetimes")

--- a/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
@@ -15,12 +15,9 @@
 
 package com.uravgcode.chooser.composables.screens
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -29,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.uravgcode.chooser.composables.settings.ResetDialog
 import com.uravgcode.chooser.composables.settings.RestartDialog
 import com.uravgcode.chooser.composables.settings.SettingsRowPercentSlider
 import com.uravgcode.chooser.composables.settings.SettingsRowSwitch
@@ -40,6 +38,7 @@ import com.uravgcode.chooser.utilities.SettingsManager
 @Composable
 fun SettingsScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
+    val showResetDialog = remember { mutableStateOf(false) }
     val showRestartDialog = remember { mutableStateOf(false) }
 
     val isSoundEnabled = remember { mutableStateOf(SettingsManager.soundEnabled) }
@@ -51,6 +50,22 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
     val groupCircleLifetime = remember { mutableLongStateOf(SettingsManager.groupCircleLifetime) }
     val orderCircleLifetime = remember { mutableLongStateOf(SettingsManager.orderCircleLifetime) }
 
+    ResetDialog(
+        showResetDialog = showResetDialog.value,
+        onDismiss = { showResetDialog.value = false },
+        onReset = {
+            SettingsManager.resetToDefault(context)
+
+            isSoundEnabled.value = SettingsManager.soundEnabled
+            isVibrationEnabled.value = SettingsManager.vibrationEnabled
+            isEdgeToEdgeEnabled.value = SettingsManager.edgeToEdgeEnabled
+            circleSizeFactor.floatValue = SettingsManager.circleSizeFactor
+            circleLifetime.longValue = SettingsManager.circleLifetime
+            groupCircleLifetime.longValue = SettingsManager.groupCircleLifetime
+            orderCircleLifetime.longValue = SettingsManager.orderCircleLifetime
+        }
+    )
+
     RestartDialog(
         showRestartDialog = showRestartDialog.value,
         onDismiss = { showRestartDialog.value = false },
@@ -59,7 +74,9 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
 
     Scaffold(
         topBar = {
-            SettingsTopAppBar(onNavigateBack)
+            SettingsTopAppBar(onNavigateBack){
+                showResetDialog.value = true
+            }
         }
     ) { padding ->
         LazyColumn(
@@ -144,17 +161,6 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
                     valueRange = 0L..3000L,
                     steps = 5,
                 )
-
-                Column(Modifier.height(50.dp)){
-                    Text("Filler1")
-                }
-                Column(Modifier.height(50.dp)){
-                    Text("Filler2")
-                }
-                Column(Modifier.height(50.dp)){
-                    Text("Filler3")
-                }
-
             }
         }
     }

--- a/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
@@ -16,10 +16,11 @@
 package com.uravgcode.chooser.composables.screens
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -61,89 +62,100 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
             SettingsTopAppBar(onNavigateBack)
         }
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .padding(padding)
-                .padding(16.dp)
+        LazyColumn(
+            modifier = Modifier.padding(padding).padding(16.dp)
         ) {
-            SettingsSeparator("General Settings", false)
+            item {
 
-            SettingsRowSwitch(
-                title = "Enable Sound",
-                isChecked = isSoundEnabled.value,
-                onCheckedChange = { isChecked ->
-                    isSoundEnabled.value = isChecked
-                    SettingsManager.soundEnabled = isChecked
+                SettingsSeparator("General Settings", false)
+
+                SettingsRowSwitch(
+                    title = "Enable Sound",
+                    isChecked = isSoundEnabled.value,
+                    onCheckedChange = { isChecked ->
+                        isSoundEnabled.value = isChecked
+                        SettingsManager.soundEnabled = isChecked
+                    }
+                )
+
+                SettingsRowSwitch(
+                    title = "Enable Vibration",
+                    isChecked = isVibrationEnabled.value,
+                    onCheckedChange = { isChecked ->
+                        isVibrationEnabled.value = isChecked
+                        SettingsManager.vibrationEnabled = isChecked
+                    }
+                )
+
+                SettingsSeparator("Display Settings")
+
+                SettingsRowSwitch(
+                    title = "Enable Edge-to-Edge",
+                    isChecked = isEdgeToEdgeEnabled.value,
+                    onCheckedChange = { isChecked ->
+                        isEdgeToEdgeEnabled.value = isChecked
+                        SettingsManager.edgeToEdgeEnabled = isChecked
+                        showRestartDialog.value = true
+                    }
+                )
+
+                SettingsRowPercentSlider(
+                    title = "Circle Size",
+                    value = circleSizeFactor.floatValue,
+                    onValueChange = { sliderValue ->
+                        circleSizeFactor.floatValue = sliderValue
+                        SettingsManager.circleSizeFactor = sliderValue
+                    },
+                    valueRange = 0.5f..1.5f,
+                    steps = 9
+                )
+
+                SettingsSeparator("Circle Lifetimes")
+
+                SettingsRowTimeSlider(
+                    title = "Circle Lifetime",
+                    value = circleLifetime.longValue,
+                    onValueChange = { sliderValue ->
+                        circleLifetime.longValue = sliderValue
+                        SettingsManager.circleLifetime = sliderValue
+                    },
+                    valueRange = 0L..3000L,
+                    steps = 5,
+                )
+
+                SettingsRowTimeSlider(
+                    title = "Group Circle Lifetime",
+                    value = groupCircleLifetime.longValue,
+                    onValueChange = { sliderValue ->
+                        groupCircleLifetime.longValue = sliderValue
+                        SettingsManager.groupCircleLifetime = sliderValue
+                    },
+                    valueRange = 0L..3000L,
+                    steps = 5,
+                )
+
+                SettingsRowTimeSlider(
+                    title = "Order Circle Lifetime",
+                    value = orderCircleLifetime.longValue,
+                    onValueChange = { sliderValue ->
+                        orderCircleLifetime.longValue = sliderValue
+                        SettingsManager.orderCircleLifetime = sliderValue
+                    },
+                    valueRange = 0L..3000L,
+                    steps = 5,
+                )
+
+                Column(Modifier.height(50.dp)){
+                    Text("Filler1")
                 }
-            )
-
-            SettingsRowSwitch(
-                title = "Enable Vibration",
-                isChecked = isVibrationEnabled.value,
-                onCheckedChange = { isChecked ->
-                    isVibrationEnabled.value = isChecked
-                    SettingsManager.vibrationEnabled = isChecked
+                Column(Modifier.height(50.dp)){
+                    Text("Filler2")
                 }
-            )
-
-            SettingsSeparator("Display Settings")
-
-            SettingsRowSwitch(
-                title = "Enable Edge-to-Edge",
-                isChecked = isEdgeToEdgeEnabled.value,
-                onCheckedChange = { isChecked ->
-                    isEdgeToEdgeEnabled.value = isChecked
-                    SettingsManager.edgeToEdgeEnabled = isChecked
-                    showRestartDialog.value = true
+                Column(Modifier.height(50.dp)){
+                    Text("Filler3")
                 }
-            )
 
-            SettingsRowPercentSlider(
-                title = "Circle Size",
-                value = circleSizeFactor.floatValue,
-                onValueChange = { sliderValue ->
-                    circleSizeFactor.floatValue = sliderValue
-                    SettingsManager.circleSizeFactor = sliderValue
-                },
-                valueRange = 0.5f..1.5f,
-                steps = 9
-            )
-
-            SettingsSeparator("Circle Lifetimes")
-
-            SettingsRowTimeSlider(
-                title = "Circle Lifetime",
-                value = circleLifetime.longValue,
-                onValueChange = { sliderValue ->
-                    circleLifetime.longValue = sliderValue
-                    SettingsManager.circleLifetime = sliderValue
-                },
-                valueRange = 0L..3000L,
-                steps = 5,
-            )
-
-            SettingsRowTimeSlider(
-                title = "Group Circle Lifetime",
-                value = groupCircleLifetime.longValue,
-                onValueChange = { sliderValue ->
-                    groupCircleLifetime.longValue = sliderValue
-                    SettingsManager.groupCircleLifetime = sliderValue
-                },
-                valueRange = 0L..3000L,
-                steps = 5,
-            )
-
-            SettingsRowTimeSlider(
-                title = "Order Circle Lifetime",
-                value = orderCircleLifetime.longValue,
-                onValueChange = { sliderValue ->
-                    orderCircleLifetime.longValue = sliderValue
-                    SettingsManager.orderCircleLifetime = sliderValue
-                },
-                valueRange = 0L..3000L,
-                steps = 5,
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/screens/SettingsScreen.kt
@@ -124,6 +124,17 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
                     }
                 )
 
+                SettingsRowPaddingSlider(
+                    title = "Additional Top Padding",
+                    value = additionalTopPadding.floatValue,
+                    onValueChange = { sliderValue ->
+                        additionalTopPadding.floatValue = sliderValue
+                        SettingsManager.additionalTopPadding = sliderValue
+                    },
+                    valueRange = 0f..50f,
+                    steps = 9
+                )
+
                 SettingsRowPercentSlider(
                     title = "Circle Size",
                     value = circleSizeFactor.floatValue,
@@ -133,17 +144,6 @@ fun SettingsScreen(onNavigateBack: () -> Unit) {
                     },
                     valueRange = 0.5f..1.5f,
                     steps = 9
-                )
-
-                SettingsRowPaddingSlider(
-                    title = "Additional Top Padding",
-                    value = additionalTopPadding.floatValue,
-                    onValueChange = { sliderValue ->
-                        additionalTopPadding.floatValue = sliderValue
-                        SettingsManager.additionalTopPadding = sliderValue
-                    },
-                    valueRange = 0f..50f,
-                    steps = 50
                 )
 
                 SettingsSeparator("Circle Lifetimes")

--- a/app/src/main/java/com/uravgcode/chooser/composables/settings/ResetDialog.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/settings/ResetDialog.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 UrAvgCode
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @author UrAvgCode
+ * @description ResetDialog shows a dialog to reset settings to default.
+ */
+
+package com.uravgcode.chooser.composables.settings
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ResetDialog(
+    showResetDialog: Boolean,
+    onDismiss: () -> Unit,
+    onReset: () -> Unit,
+) {
+    if (showResetDialog) {
+        AlertDialog(
+            onDismissRequest = { onDismiss() },
+            title = { Text(text = "Reset Settings") },
+            text = { Text(text = "Are you sure you want to reset all settings to their default values?") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onReset()
+                        onDismiss()
+                    }
+                ) {
+                    Text("Reset")
+                }
+            },
+            dismissButton = {
+                Button(onClick = { onDismiss() }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/uravgcode/chooser/composables/settings/SettingsRowPaddingSlider.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/settings/SettingsRowPaddingSlider.kt
@@ -1,0 +1,39 @@
+package com.uravgcode.chooser.composables.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+@Composable
+fun SettingsRowPaddingSlider(
+    title: String,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Text(
+            text = "$title: ${(value).roundToInt()}",
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+        )
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+            steps = steps,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/uravgcode/chooser/composables/settings/SettingsTopAppBar.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/settings/SettingsTopAppBar.kt
@@ -18,10 +18,12 @@ package com.uravgcode.chooser.composables.settings
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -30,10 +32,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun SettingsTopAppBar(onNavigateBack: () -> Unit) {
+fun SettingsTopAppBar(onNavigateBack: () -> Unit, onReset: () -> Unit) {
     TopAppBar(
         modifier = Modifier.windowInsetsPadding(
             WindowInsets.safeContent.only(WindowInsetsSides.Top)
@@ -51,6 +54,13 @@ fun SettingsTopAppBar(onNavigateBack: () -> Unit) {
                     contentDescription = "Back"
                 )
             }
+        },
+        actions = {
+            ElevatedButton(
+                content = { Text("reset") },
+                onClick = { onReset() },
+                modifier = Modifier.padding(8.dp)
+            )
         }
     )
 }

--- a/app/src/main/java/com/uravgcode/chooser/composables/settings/SettingsTopAppBar.kt
+++ b/app/src/main/java/com/uravgcode/chooser/composables/settings/SettingsTopAppBar.kt
@@ -18,12 +18,10 @@ package com.uravgcode.chooser.composables.settings
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,11 +30,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun SettingsTopAppBar(onNavigateBack: () -> Unit, onReset: () -> Unit) {
+fun SettingsTopAppBar(onNavigateBack: () -> Unit) {
     TopAppBar(
         modifier = Modifier.windowInsetsPadding(
             WindowInsets.safeContent.only(WindowInsetsSides.Top)
@@ -54,13 +51,6 @@ fun SettingsTopAppBar(onNavigateBack: () -> Unit, onReset: () -> Unit) {
                     contentDescription = "Back"
                 )
             }
-        },
-        actions = {
-            ElevatedButton(
-                content = { Text("reset") },
-                onClick = { onReset() },
-                modifier = Modifier.padding(8.dp)
-            )
         }
     )
 }

--- a/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
+++ b/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
@@ -22,6 +22,7 @@ import com.uravgcode.chooser.circles.Circle
 import com.uravgcode.chooser.circles.GroupCircle
 import com.uravgcode.chooser.circles.OrderCircle
 import com.uravgcode.chooser.views.Chooser
+import androidx.core.content.edit
 
 object SettingsManager {
     private lateinit var preferences: SharedPreferences
@@ -41,60 +42,65 @@ object SettingsManager {
     var mode: Mode
         get() = Mode.entries[preferences.getInt("mode", 0)]
         set(value) {
-            preferences.edit().putInt("mode", value.ordinal).apply()
+            preferences.edit { putInt("mode", value.ordinal) }
         }
 
     var count: Int
         get() = preferences.getInt("count", 1)
         set(value) {
-            preferences.edit().putInt("count", value).apply()
+            preferences.edit { putInt("count", value) }
         }
 
     var soundEnabled: Boolean
         get() = preferences.getBoolean("sound", true)
         set(value) {
-            preferences.edit().putBoolean("sound", value).apply()
+            preferences.edit { putBoolean("sound", value) }
             SoundManager.soundEnabled = value
         }
 
     var vibrationEnabled: Boolean
         get() = preferences.getBoolean("vibration", true)
         set(value) {
-            preferences.edit().putBoolean("vibration", value).apply()
+            preferences.edit { putBoolean("vibration", value) }
             Chooser.vibrationEnabled = value
         }
 
     var edgeToEdgeEnabled: Boolean
         get() = preferences.getBoolean("edge_to_edge", false)
         set(value) {
-            preferences.edit().putBoolean("edge_to_edge", value).apply()
+            preferences.edit { putBoolean("edge_to_edge", value) }
         }
 
     var circleSizeFactor: Float
         get() = preferences.getFloat("circle_size_factor", 1.0f)
         set(value) {
-            preferences.edit().putFloat("circle_size_factor", value).apply()
+            preferences.edit { putFloat("circle_size_factor", value) }
             Chooser.circleSizeFactor = value
         }
 
     var circleLifetime: Long
         get() = preferences.getLong("circle_lifetime", 1000)
         set(value) {
-            preferences.edit().putLong("circle_lifetime", value).apply()
+            preferences.edit { putLong("circle_lifetime", value) }
             Circle.circleLifetime = value
         }
 
     var groupCircleLifetime: Long
         get() = preferences.getLong("group_circle_lifetime", 1000)
         set(value) {
-            preferences.edit().putLong("group_circle_lifetime", value).apply()
+            preferences.edit { putLong("group_circle_lifetime", value) }
             GroupCircle.circleLifetime = value
         }
 
     var orderCircleLifetime: Long
         get() = preferences.getLong("order_circle_lifetime", 1500)
         set(value) {
-            preferences.edit().putLong("order_circle_lifetime", value).apply()
+            preferences.edit { putLong("order_circle_lifetime", value) }
             OrderCircle.circleLifetime = value
         }
+
+    fun resetToDefault(context: Context) {
+        preferences.edit { clear() }
+        init(context)
+    }
 }

--- a/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
+++ b/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
@@ -9,7 +9,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * @author UrAvgCode
+ * @author UrAvgCode, Patch4Code
  * @description SettingsManager manages the application settings.
  */
 
@@ -18,18 +18,21 @@ package com.uravgcode.chooser.utilities
 import android.app.Activity.MODE_PRIVATE
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.uravgcode.chooser.circles.Circle
 import com.uravgcode.chooser.circles.GroupCircle
 import com.uravgcode.chooser.circles.OrderCircle
 import com.uravgcode.chooser.views.Chooser
-import androidx.core.content.edit
 
 object SettingsManager {
     private lateinit var preferences: SharedPreferences
 
     fun init(context: Context) {
         preferences = context.getSharedPreferences("settings", MODE_PRIVATE)
+        initializeSettings()
+    }
 
+    private fun initializeSettings() {
         SoundManager.soundEnabled = soundEnabled
         Chooser.vibrationEnabled = vibrationEnabled
         Chooser.circleSizeFactor = circleSizeFactor
@@ -105,9 +108,8 @@ object SettingsManager {
             OrderCircle.circleLifetime = value
         }
 
-
-    fun resetToDefault(context: Context) {
+    fun reset() {
         preferences.edit { clear() }
-        init(context)
+        initializeSettings()
     }
 }

--- a/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
+++ b/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
@@ -78,6 +78,12 @@ object SettingsManager {
             Chooser.circleSizeFactor = value
         }
 
+    var additionalTopPadding: Float
+        get() = preferences.getFloat("additional_top_padding", 0.0f)
+        set(value) {
+            preferences.edit { putFloat("additional_top_padding", value) }
+        }
+
     var circleLifetime: Long
         get() = preferences.getLong("circle_lifetime", 1000)
         set(value) {
@@ -98,6 +104,7 @@ object SettingsManager {
             preferences.edit { putLong("order_circle_lifetime", value) }
             OrderCircle.circleLifetime = value
         }
+
 
     fun resetToDefault(context: Context) {
         preferences.edit { clear() }

--- a/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
+++ b/app/src/main/java/com/uravgcode/chooser/utilities/SettingsManager.kt
@@ -74,17 +74,17 @@ object SettingsManager {
             preferences.edit { putBoolean("edge_to_edge", value) }
         }
 
+    var additionalTopPadding: Float
+        get() = preferences.getFloat("additional_top_padding", 0.0f)
+        set(value) {
+            preferences.edit { putFloat("additional_top_padding", value) }
+        }
+
     var circleSizeFactor: Float
         get() = preferences.getFloat("circle_size_factor", 1.0f)
         set(value) {
             preferences.edit { putFloat("circle_size_factor", value) }
             Chooser.circleSizeFactor = value
-        }
-
-    var additionalTopPadding: Float
-        get() = preferences.getFloat("additional_top_padding", 0.0f)
-        set(value) {
-            preferences.edit { putFloat("additional_top_padding", value) }
         }
 
     var circleLifetime: Long


### PR DESCRIPTION
I fixed the problem on the settings screen, where the scrolled elements would appear above the topBar. Additionally I implemented a rest button for the settings and a slider to add additional top padding (possibility to prevent collision with notch on left/right side of the screen).